### PR TITLE
Support assuming role

### DIFF
--- a/ecs_update_monitor/cli.py
+++ b/ecs_update_monitor/cli.py
@@ -1,4 +1,5 @@
 import argparse
+from re import match
 
 from boto3 import Session
 
@@ -14,10 +15,40 @@ def parse_args(argv):
     parser.add_argument('--service', help='ECS service name.', required=True)
     parser.add_argument('--taskdef', help='ECS taskdef ARN.', required=True)
     parser.add_argument('--region', help='AWS region.', required=True)
+    parser.add_argument(
+        '--caller-arn', help='ARN of caller.', required=False
+    )
     return parser.parse_args(argv)
+
+
+def switch_role(sts, caller_arn, region):
+    m = match(
+        r'arn:aws:sts::(\d+):assumed-role/'
+        r'([\w+=,.@_/-]{1,64})/([\w=,.@-]{0,64})$',
+        caller_arn
+    )
+    if m is None:
+        raise Exception(
+            'IAM caller did not match terraform, but caller arn did not '
+            'match expected pattern ("{}")'.format(caller_arn)
+        )
+    response = sts.assume_role(
+        RoleArn='arn:aws:iam::{}:role/{}'.format(m.group(1), m.group(2)),
+        RoleSessionName=m.group(3)
+    )
+    return Session(
+        aws_access_key_id=response['Credentials']['AccessKeyId'],
+        aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+        aws_session_token=response['Credentials']['SessionToken'],
+        region_name=region
+    )
 
 
 def main(argv):
     args = parse_args(argv)
     session = Session(region_name=args.region)
+    sts = session.client('sts')
+    caller = sts.get_caller_identity()
+    if caller['Arn'] != args.caller_arn:
+        session = switch_role(sts, args.caller_arn, args.region)
     run(args.cluster, args.service, args.taskdef, session)

--- a/main.tf
+++ b/main.tf
@@ -24,11 +24,11 @@ resource "null_resource" "ecs_update_monitor" {
     cluster    = "${var.cluster}"
     service    = "${var.service}"
     taskdef    = "${var.taskdef}"
-    caller_arn = "${data.aws_caller_identity.current.caller_arn}"
+    caller_arn = "${data.aws_caller_identity.current.arn}"
     region     = "${data.aws_region.current.name}"
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/provision.sh '${path.module}' '${var.cluster}' '${var.service}' '${var.taskdef}' '${data.aws_region.current.name}' '${data.aws_caller_identity.current.caller_arn}'"
+    command = "${path.module}/provision.sh '${path.module}' '${var.cluster}' '${var.service}' '${var.taskdef}' '${data.aws_region.current.name}' '${data.aws_caller_identity.current.arn}'"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -17,15 +17,18 @@ data "aws_region" "current" {
   current = true
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "null_resource" "ecs_update_monitor" {
   triggers {
-    cluster = "${var.cluster}"
-    service = "${var.service}"
-    taskdef = "${var.taskdef}"
-    region  = "${data.aws_region.current.name}"
+    cluster    = "${var.cluster}"
+    service    = "${var.service}"
+    taskdef    = "${var.taskdef}"
+    caller_arn = "${data.aws_caller_identity.current.caller_arn}"
+    region     = "${data.aws_region.current.name}"
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/provision.sh '${path.module}' '${var.cluster}' '${var.service}' '${var.taskdef}' '${data.aws_region.current.name}'"
+    command = "${path.module}/provision.sh '${path.module}' '${var.cluster}' '${var.service}' '${var.taskdef}' '${data.aws_region.current.name}' '${data.aws_caller_identity.current.caller_arn}'"
   }
 }

--- a/provision.sh
+++ b/provision.sh
@@ -3,13 +3,14 @@
 set -e
 
 if [ "$#" != "5" ]; then
-    echo 'Usage: provision.sh <module-root> <cluster> <service> <taskdef> <region>' >&2
+    echo 'Usage: provision.sh <module-root> <cluster> <service> <taskdef> <region> <caller-arn>' >&2
     exit 1
 fi
 
 cd "$1"
 
-python -m ecs_update_monitor --cluster "$2" \
-                             --service "$3" \
-                             --taskdef "$4" \
-                             --region  "$5"
+python -m ecs_update_monitor --cluster    "$2" \
+                             --service    "$3" \
+                             --taskdef    "$4" \
+                             --region     "$5" \
+                             --caller-arn "$6"

--- a/provision.sh
+++ b/provision.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "$#" != "5" ]; then
+if [ "$#" != "6" ]; then
     echo 'Usage: provision.sh <module-root> <cluster> <service> <taskdef> <region> <caller-arn>' >&2
     exit 1
 fi

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 from contextlib import contextmanager
 
 try:
@@ -8,7 +9,7 @@ except ImportError:
 
 import sys
 
-from mock import Mock, patch
+from mock import Mock, patch, ANY
 from string import ascii_letters, digits
 from hypothesis import given, assume
 from hypothesis.strategies import text, fixed_dictionaries
@@ -17,6 +18,8 @@ from ecs_update_monitor import cli
 
 
 IDENTIFIERS = ascii_letters + digits + '-_'
+ROLE_NAMES = ascii_letters + digits + '+=,.@_-/'
+SESSION_NAMES = ascii_letters + digits + '=,.@-'
 
 
 @contextmanager
@@ -58,6 +61,7 @@ class TestECSMonitorCLI(unittest.TestCase):
         'service': text(min_size=1, alphabet=IDENTIFIERS),
         'taskdef': text(min_size=1, alphabet=IDENTIFIERS),
         'region': text(min_size=1, alphabet=IDENTIFIERS),
+        'caller_arn': text(min_size=1, alphabet=IDENTIFIERS),
     }))
     def test_command_line_paramters_used(self, fixtures):
 
@@ -65,31 +69,111 @@ class TestECSMonitorCLI(unittest.TestCase):
         assume(fixtures['service'][0] != '-')
         assume(fixtures['taskdef'][0] != '-')
         assume(fixtures['region'][0] != '-')
+        assume(fixtures['caller_arn'][0] != '-')
 
         # Given
         with patch('ecs_update_monitor.cli.Session') as Session, \
                 patch('ecs_update_monitor.cli.run') as run:
 
-            session = Mock()
-            Session.return_value = session
-
             cluster = fixtures['cluster']
             service = fixtures['service']
             taskdef = fixtures['taskdef']
             region = fixtures['region']
+            caller_arn = fixtures['caller_arn']
 
-            print("cluster {} service {} taskdef {} region {}".format(
-                cluster, service, taskdef, region
-            ))
+            session = Mock()
+            Session.return_value = session
+            mock_sts = Mock()
+            mock_sts.get_caller_identity.return_value = {
+                "Arn": caller_arn
+            }
+            session.client.return_value = mock_sts
 
             # When
             cli.main([
                 '--cluster', cluster, '--service', service,
                 '--taskdef', taskdef, '--region', region,
+                '--caller-arn', caller_arn
             ])
 
             # Then
             Session.assert_called_once_with(region_name=region)
+            session.client.assert_called_once_with('sts')
+            mock_sts.get_caller_identity.assert_called_once_with()
             run.assert_called_once_with(
                 cluster, service, taskdef, session
+            )
+
+    @given(fixed_dictionaries({
+        'region': text(min_size=1, alphabet=IDENTIFIERS),
+        'role': text(min_size=1, max_size=64, alphabet=ROLE_NAMES),
+        'session_name': text(min_size=1, max_size=64, alphabet=SESSION_NAMES),
+        'account_id': text(min_size=1, alphabet=digits),
+        'access_key': text(min_size=1, alphabet=IDENTIFIERS),
+        'secret_key': text(min_size=1, alphabet=IDENTIFIERS),
+        'token': text(min_size=1, alphabet=IDENTIFIERS),
+    }))
+    def test_role_assumed(self, fixtures):
+
+        assume(fixtures['region'][0] != '-')
+
+        # Given
+        with patch('ecs_update_monitor.cli.Session') as Session, \
+                patch('ecs_update_monitor.cli.run') as run:
+
+            root_session = Mock()
+            assumed_session = Mock()
+
+            def SessionContructor(
+                aws_access_key_id=None, aws_secret_access_key=None,
+                aws_session_token=None, region_name=None
+            ):
+                if aws_access_key_id is not None:
+                    return assumed_session
+                else:
+                    return root_session
+
+            Session.side_effect = SessionContructor
+            mock_sts = Mock()
+            mock_sts.get_caller_identity.return_value = {
+                'Arn': 'something-not-the-same'
+            }
+            mock_sts.assume_role.return_value = {
+                'Credentials': {
+                    'AccessKeyId': fixtures['access_key'],
+                    'SecretAccessKey': fixtures['secret_key'],
+                    'SessionToken': fixtures['token'],
+                    'Expiration': datetime(2015, 1, 1),
+                }
+            }
+            root_session.client.return_value = mock_sts
+
+            # When
+            cli.main([
+                '--cluster', 'dummy', '--service', 'dummy',
+                '--taskdef', 'dummy', '--region', fixtures['region'],
+                '--caller-arn', 'arn:aws:sts::{}:assumed-role/{}/{}'.format(
+                    fixtures['account_id'], fixtures['role'],
+                    fixtures['session_name']
+                ),
+            ])
+
+            # Then
+            Session.assert_any_call(region_name=fixtures['region'])
+            root_session.client.assert_called_once_with('sts')
+            mock_sts.get_caller_identity.assert_called_once_with()
+            mock_sts.assume_role.assert_called_once_with(
+                RoleArn='arn:aws:iam::{}:role/{}'.format(
+                    fixtures['account_id'], fixtures['role']
+                ),
+                RoleSessionName=fixtures['session_name'],
+            )
+            Session.assert_any_call(
+                region_name=fixtures['region'],
+                aws_access_key_id=fixtures['access_key'],
+                aws_secret_access_key=fixtures['secret_key'],
+                aws_session_token=fixtures['token'],
+            )
+            run.assert_called_once_with(
+                ANY, ANY, ANY, assumed_session
             )


### PR DESCRIPTION
In the case where we use terraform provider config to assume a role,
the aws credentials in the environment are not updated so this module
will no be in the correct account. This change detects when this is
the case and assumes the correct role.