### PR TITLE
PLAT-822 Clean up dev experience on deploy

### DIFF
--- a/ecs_update_monitor/__init__.py
+++ b/ecs_update_monitor/__init__.py
@@ -1,8 +1,5 @@
 from time import sleep, time
 
-from ecs_update_monitor.logger import logger
-
-
 MAX_FAILURES = 3
 
 
@@ -32,11 +29,8 @@ class ECSMonitor:
     def _check_ecs_deploy_progress(self):
         start = time()
         for event in self._ecs_event_iterator:
-            self._show_deployment_progress(event)
             self._check_for_failed_tasks(event)
-
             if event.done:
-                logger.info('Deployment complete')
                 return True
             if time() - start > self._TIMEOUT:
                 raise TimeoutError(
@@ -44,18 +38,6 @@ class ECSMonitor:
                     'within {} seconds'.format(self._TIMEOUT)
                 )
             sleep(self._INTERVAL)
-
-    def _show_deployment_progress(self, event):
-        for message in event.messages:
-            logger.info('ECS service event - {}'.format(message))
-
-        logger.info(
-            'ECS service tasks - '
-            'desired: {} pending: {} running: {} previous: {}'.format(
-                event.desired, event.pending,
-                event.running, event.previous_running
-            )
-        )
 
     def _check_for_failed_tasks(self, event):
         if event.running < self._previous_running_count:

--- a/ecs_update_monitor/__init__.py
+++ b/ecs_update_monitor/__init__.py
@@ -1,4 +1,5 @@
 from time import sleep, time
+from ecs_update_monitor import logger
 
 MAX_FAILURES = 3
 
@@ -29,6 +30,7 @@ class ECSMonitor:
     def _check_ecs_deploy_progress(self):
         start = time()
         for event in self._ecs_event_iterator:
+            self._show_deployment_progress(event)
             self._check_for_failed_tasks(event)
             if event.done:
                 return True
@@ -38,6 +40,10 @@ class ECSMonitor:
                     'within {} seconds'.format(self._TIMEOUT)
                 )
             sleep(self._INTERVAL)
+
+    def _show_deployment_progress(self, event):
+        for message in event.messages:
+            logger.info(message)
 
     def _check_for_failed_tasks(self, event):
         if event.running < self._previous_running_count:

--- a/ecs_update_monitor/cli.py
+++ b/ecs_update_monitor/cli.py
@@ -3,7 +3,7 @@ from re import match
 
 from boto3 import Session
 
-from ecs_update_monitor import run, FailedTasksError
+from ecs_update_monitor import run, UserFacingError
 from ecs_update_monitor.logger import logger
 
 
@@ -54,5 +54,5 @@ def main(argv):
         session = switch_role(sts, args.caller_arn, args.region)
     try:
         run(args.cluster, args.service, args.taskdef, session)
-    except FailedTasksError as e:
+    except UserFacingError as e:
         logger.error(str(e))

--- a/ecs_update_monitor/logger.py
+++ b/ecs_update_monitor/logger.py
@@ -1,7 +1,7 @@
 import logging
 
 logging.basicConfig(
-    format='[%(asctime)s] %(message)s',
+    format='%(levelname)s: %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 logger = logging.getLogger(__name__)

--- a/ecs_update_monitor/logger.py
+++ b/ecs_update_monitor/logger.py
@@ -1,7 +1,7 @@
 import logging
 
 logging.basicConfig(
-    format='%(levelname)s: %(message)s',
+    format='%(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 logger = logging.getLogger(__name__)

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@ docker run \
     $(tty -s && echo -v $(pwd)/.hypothesis/:/usr/src/app/.hypothesis/) \
     $image py.test \
         -n auto \
-        --cov=. \
+        --cov=./ecs_update_monitor \
         --cov-report term-missing \
         --tb=short \
         "$@"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,6 +9,7 @@ except ImportError:
 
 import sys
 
+from itertools import cycle
 from mock import Mock, patch, ANY
 from string import ascii_letters, digits
 from hypothesis import given, assume
@@ -244,4 +245,63 @@ class TestECSMonitorCLI(unittest.TestCase):
         assert logs.output == [(
             'ERROR:ecs_update_monitor.logger:Deployment failed - '
             '3 new tasks have failed'
+        )]
+
+    @patch('ecs_update_monitor.ECSMonitor')
+    @patch('ecs_update_monitor.ECSEventIterator')
+    @patch('ecs_update_monitor.cli.Session')
+    def test_run_timeout_error(self, mock_session, mock_iter, mock_monitor):
+        # Given
+        root_session = Mock()
+        assumed_session = Mock()
+
+        def SessionContructor(
+            aws_access_key_id=None, aws_secret_access_key=None,
+            aws_session_token=None, region_name=None
+        ):
+            if aws_access_key_id is not None:
+                return assumed_session
+            else:
+                return root_session
+
+        mock_session.side_effect = SessionContructor
+        mock_arn = 'arn:aws:sts::{}:assumed-role/{}/{}'.format(
+                '1234567890', 'role', 'session_name'
+        )
+        mock_sts = Mock()
+        mock_sts.get_caller_identity.return_value = {
+            'Arn': mock_arn
+        }
+        mock_sts.assume_role.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key',
+                'SecretAccessKey': 'secret_key',
+                'SessionToken': 'token',
+                'Expiration': datetime(2015, 1, 1),
+            }
+        }
+        root_session.client.return_value = mock_sts
+        mock_iter.return_value = Mock()
+
+        ecs_event_iterator = cycle([
+            InProgressEvent(0, 0, 2, 0, []),
+            InProgressEvent(0, 0, 2, 0, []),
+        ])
+        ecs_monitor = ECSMonitor(ecs_event_iterator)
+        ecs_monitor._INTERVAL = 0.1
+        ecs_monitor._TIMEOUT = 0.1
+        mock_monitor.return_value = ecs_monitor
+        # When
+        with unittest.TestCase.assertLogs(
+            self, 'ecs_update_monitor.logger', level='ERROR'
+        ) as logs:
+            cli.main([
+                '--cluster', 'dummy', '--service', 'dummy',
+                '--taskdef', 'dummy', '--region', 'region',
+                '--caller-arn', mock_arn
+            ])
+        # Then
+        assert logs.output == [(
+            'ERROR:ecs_update_monitor.logger:Deployment timed out - '
+            'didn\'t complete within 0.1 seconds'
         )]


### PR DESCRIPTION
This cleans up the developer experience on deploy. Might need to do some tweaking around the log name but it does remove a lot of output from the console.